### PR TITLE
release 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.3] - 0.5.3
+## [0.5.4] - 2026-04-16
+
+### Fixed
+
+- Fix bad crash because use of child components (list-item, aspect-ratio, etc...) import KitComponent-Item with preprocessor Lili.
+
+## [0.5.3] - 2026-04-11
 
 **New package [eslint-config-lapikit](https://www.npmjs.com/package/eslint-config-lapikit)** for share eslint config for lapikit and all project with lapikit, with support for svelte and typescript.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lapikit",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"license": "MIT",
 	"publishConfig": {
 		"access": "public"

--- a/src/lib/__test__/lili-core.test.ts
+++ b/src/lib/__test__/lili-core.test.ts
@@ -30,6 +30,13 @@ describe('liliCore', () => {
 		expect(result?.code).toContain(`import { ${sheetName} } from '${lapikitImportsLabsRef}';`);
 	});
 
+	it('converts hyphenated component names to PascalCase', () => {
+		expect(componentName('list-item')).toBe('KitListItem');
+		expect(componentName('accordion-item')).toBe('KitAccordionItem');
+		expect(componentName('aspect-ratio')).toBe('KitAspectRatio');
+		expect(componentName('list')).toBe('KitList');
+	});
+
 	it('does nothing when kit tags exist only inside script or style', () => {
 		const preprocess = liliCore();
 		const input = `<script>\n\tconst template = '<kit:sheet />';\n</script>\n\n<style>\n\t.example::before { content: "<kit:sheet />"; }\n</style>`;

--- a/src/lib/__test__/lili-core.test.ts
+++ b/src/lib/__test__/lili-core.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { componentName, liliCore } from '$lib/framework';
-import { lapikitImportsLabsRef } from '$lib/constants';
+import { lapikitImportsLabsRef, lapikitImportsRef } from '$lib/constants';
 
 describe('liliCore', () => {
 	it('converts kit tags with multiline attributes and injects imports', () => {
@@ -35,6 +35,21 @@ describe('liliCore', () => {
 		expect(componentName('accordion-item')).toBe('KitAccordionItem');
 		expect(componentName('aspect-ratio')).toBe('KitAspectRatio');
 		expect(componentName('list')).toBe('KitList');
+	});
+
+	it('generates a single import for kit:list and kit:list-item without duplicates', () => {
+		const preprocess = liliCore();
+		const input = `<script></script>\n<kit:list>\n\t<kit:list-item />\n</kit:list>`;
+
+		const result = preprocess.markup({ content: input });
+		const code = result?.code ?? '';
+
+		const matches = [...code.matchAll(/import\s*\{[^}]*KitList[^}]*\}/g)];
+		expect(matches).toHaveLength(1);
+		expect(code).toContain('KitList,');
+		expect(code).toContain('KitListItem');
+		expect(code).toContain(`from '${lapikitImportsRef}'`);
+		expect(code).not.toContain('KitList-item');
 	});
 
 	it('does nothing when kit tags exist only inside script or style', () => {

--- a/src/lib/framework.ts
+++ b/src/lib/framework.ts
@@ -14,7 +14,8 @@ import {
  * @returns The component name with "Kit" prefix and the first letter capitalized
  */
 export function componentName(shortName: string): string {
-	return 'Kit' + shortName.charAt(0).toUpperCase() + shortName.slice(1);
+	const pascal = shortName.replace(/(^|-)([a-z])/g, (_, __, letter) => letter.toUpperCase());
+	return 'Kit' + pascal;
 }
 
 export function liliCore(options?: LapikitPreprocessOptions) {


### PR DESCRIPTION
### Fixed

- Fix bad crash because use of child components (list-item, aspect-ratio, etc...) import KitComponent-Item with preprocessor Lili.