### PR TITLE
release 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.5] - 2026-04-22
+
+### Added
+
+- New type `ModelAccordionItemProps` for snippet activator props to accordion components.
+
+### Fixed
+
+- Conflic CSS background on component Accordion
+- Rename bad import `accordionIten` to `accordion-item`
+- Fix filled variant not working on Toolbar component
+- Fix density component List not working
+- Fix state active on List Item not working on CSS render
+
 ## [0.5.4] - 2026-04-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lapikit",
-	"version": "0.5.4",
+	"version": "0.5.5",
 	"license": "MIT",
 	"publishConfig": {
 		"access": "public"

--- a/src/lib/components/accordion/accordion.types.ts
+++ b/src/lib/components/accordion/accordion.types.ts
@@ -1,6 +1,10 @@
 import type { RoundedType, Component } from '$lib/@types';
 import type { Snippet } from 'svelte';
 
+export type ModelAccordionItemProps = {
+	open: boolean;
+};
+
 export interface AccordionProps extends Component {
 	ref?: HTMLElement | null;
 	is?: 'div';

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -1,5 +1,6 @@
 // types
 export type { ModelDropdownProps } from './dropdown/dropdown.types';
+export type { ModelAccordionItemProps } from './accordion/accordion.types';
 
 // components
 export { default as KitApp } from './app/app.svelte';

--- a/src/lib/components/list/list.svelte
+++ b/src/lib/components/list/list.svelte
@@ -118,6 +118,7 @@
 		--kit-list-item-px: var(--kit-list-item-px-md);
 		--kit-list-item-gap: var(--kit-list-item-gap-md);
 		--kit-list-item-font: var(--kit-list-item-font-md);
+		--kit-list-density-offset: 0rem;
 
 		display: flex;
 		flex-direction: column;
@@ -169,11 +170,11 @@
 	}
 
 	.kit-list[data-density='compact'] {
-		--kit-list-item-h: calc(var(--kit-list-item-h) - 0.25rem);
+		--kit-list-density-offset: -0.25rem;
 	}
 
 	.kit-list[data-density='comfortable'] {
-		--kit-list-item-h: calc(var(--kit-list-item-h) + 0.25rem);
+		--kit-list-density-offset: 0.25rem;
 	}
 
 	.kit-list[data-rounded='0'] {

--- a/src/lib/components/list/modules/list-item.svelte
+++ b/src/lib/components/list/modules/list-item.svelte
@@ -146,6 +146,10 @@
 		background: var(--kit-list-item-bg, transparent);
 	}
 
+	:global(.kit-list[data-variant='filled']) .kit-list-item[data-active='true'] {
+		background: color-mix(in oklab, currentColor 12%, transparent);
+	}
+
 	:global(.kit-list[data-variant='outline']) .kit-list-item::before {
 		content: '';
 		position: absolute;

--- a/src/lib/components/list/modules/list-item.svelte
+++ b/src/lib/components/list/modules/list-item.svelte
@@ -106,7 +106,7 @@
 		grid-template-columns: auto minmax(0, 1fr) auto;
 		align-items: center;
 		gap: var(--kit-list-item-gap, 0.625rem);
-		min-height: var(--kit-list-item-h, 2.75rem);
+		min-height: calc(var(--kit-list-item-h, 2.75rem) + var(--kit-list-density-offset, 0rem));
 		padding-inline: var(--kit-list-item-px, 0.875rem);
 		border: 0;
 		border-radius: var(--kit-list-item-radius);

--- a/src/lib/components/toolbar/toolbar.svelte
+++ b/src/lib/components/toolbar/toolbar.svelte
@@ -12,7 +12,7 @@
 		's-class': sClass,
 		's-style': sStyle,
 		classContent,
-		variant = 'text',
+		variant = 'filled',
 		rounded,
 		background,
 		color,
@@ -24,9 +24,9 @@
 
 	let safeVariant = $derived(
 		typeof variant === 'string' &&
-			(variant === 'outline' || variant === 'text' || variant === 'dash')
+			(variant === 'filled' || variant === 'outline' || variant === 'text' || variant === 'dash')
 			? variant
-			: 'text'
+			: 'filled'
 	);
 
 	let safeDensity = $derived(

--- a/src/lib/components/toolbar/toolbar.types.ts
+++ b/src/lib/components/toolbar/toolbar.types.ts
@@ -1,6 +1,6 @@
 import type { Component, PropValue, RoundedType } from '$lib/@types';
 
-type Variant = 'outline' | 'text' | 'dash';
+type Variant = 'filled' | 'outline' | 'text' | 'dash';
 type Density = 'compact' | 'comfortable' | 'default';
 type Orientation = 'horizontal' | 'vertical';
 type Location = 'top' | 'bottom';

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -23,7 +23,7 @@ export const lapikitComponents: readonly string[] = [
 	'dialog',
 	'modal',
 	'accordion',
-	'accordionItem',
+	'accordion-item',
 	'alert',
 	'aspect-ratio',
 	'spacer',


### PR DESCRIPTION
### Added

- New type `ModelAccordionItemProps` for snippet activator props to accordion components.

### Fixed

- Conflic CSS background on component Accordion
- Rename bad import `accordionIten` to `accordion-item`
- Fix filled variant not working on Toolbar component
- Fix density component List not working
- Fix state active on List Item not working on CSS render